### PR TITLE
build docker image with sendgrid api key and ec public key

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,51 +2,51 @@ name: Build-Push kotal cloud api
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Generate Docker metadata
-      id: meta
-      uses: docker/metadata-action@v3
-      with:
-        images: |
-          docker.io/kotalco/cloud-api
-        tags: |
-          type=ref,event=tag
-          type=sha,prefix=,suffix=,format=short
-        flavor: |
-          latest=true
+      - name: Generate Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            docker.io/kotalco/cloud-api
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=,suffix=,format=short
+          flavor: |
+            latest=true
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: kotalco
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v2
-      with:
-        username: kotalco
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
-    - name: Build and push
-      uses: docker/build-push-action@v3
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: true
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          secrets: |
+            "SENDGRID_API_KEY=${{ secrets.SENDGRID_API_KEY }}"
+            "EC_PUBLIC_KEY=${{ secrets.EC_PUBLIC_KEY }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ WORKDIR /api
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -v -o server
+ARG EC_PUBLIC_KEY
+ARG SENDGRID_API_KEY
+
+RUN CGO_ENABLED=0 go build -ldflags="-X 'github.com/kotalco/cloud-api/pkg/config.SendgridAPIKey=${SENDGRID_API_KEY}' -X 'github.com/kotalco/cloud-api/pkg/config.ECCPublicKey=${EC_PUBLIC_KEY}'" -v -o server
 
 FROM alpine
 


### PR DESCRIPTION
Pass elliptic curve public key and sendgrid API key from:
Github secrets ➡ Github docker action ➡ docker file ➡ Golang build-time variables.
The end result is go binary with sendgrid api key and ec public key set, and ready to use if environment is production.