### PR TITLE
update docker image with EC_pub_key for staging/prod

### DIFF
--- a/.github/workflows/build-push-production-docker.yml
+++ b/.github/workflows/build-push-production-docker.yml
@@ -1,4 +1,4 @@
-name: Build-Push kotal cloud api
+name: Build-Push-production-cloud-api
 
 on:
   push:

--- a/.github/workflows/build-push-staging-docker.yml
+++ b/.github/workflows/build-push-staging-docker.yml
@@ -1,4 +1,4 @@
-name: Build-Push kotal cloud api
+name: Build-Push-staging-cloud-api
 
 on:
   push:


### PR DESCRIPTION
fixes issue #208 

Build docker image from GitHub secret called STAGING_EC_PUBLIC_KEY if commit is not tagged.
Build docker image from GitHub secret called PRODUCTION_EC_PUBLIC_KEY if commit is tagged with v* tags.