### PR TITLE
feat:mark cloud-api users with IsCustomer false and managed-api usere…

### DIFF
--- a/api/handler/user/handler.go
+++ b/api/handler/user/handler.go
@@ -59,7 +59,7 @@ func SignUp(c *fiber.Ctx) error {
 	sqlclient.Commit(txRead)
 
 	txHandle := sqlclient.Begin()
-	model, restErr := userService.WithTransaction(txHandle).SignUp(dto)
+	model, restErr := userService.WithTransaction(txHandle).SignUp(dto.Email, dto.Password, false)
 	if restErr != nil {
 		sqlclient.Rollback(txHandle)
 		return c.Status(restErr.StatusCode()).JSON(restErr)

--- a/api/handler/user/handler_test.go
+++ b/api/handler/user/handler_test.go
@@ -33,7 +33,7 @@ User service Mocks
 */
 var (
 	UserWithTransactionFunc     func(txHandle *gorm.DB) user.IService
-	SignUpFunc                  func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr)
+	SignUpFunc                  func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr)
 	SignInFunc                  func(dto *user.SignInRequestDto) (*user.UserSessionResponseDto, restErrors.IRestErr)
 	VerifyTOTPFunc              func(model *user.User, totp string) (*user.UserSessionResponseDto, restErrors.IRestErr)
 	GetByEmailFunc              func(email string) (*user.User, restErrors.IRestErr)
@@ -60,8 +60,8 @@ func (uService userServiceMock) WithTransaction(txHandle *gorm.DB) user.IService
 	return uService
 }
 
-func (userServiceMock) SignUp(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
-	return SignUpFunc(dto)
+func (userServiceMock) SignUp(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
+	return SignUpFunc(email, password, isCustomer)
 }
 
 func (userServiceMock) SignIn(dto *user.SignInRequestDto) (*user.UserSessionResponseDto, restErrors.IRestErr) {
@@ -375,7 +375,7 @@ func TestSignUp(t *testing.T) {
 		settingIsRegistrationEnabledFunc = func() bool {
 			return true
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			newUser := new(user.User)
 			newUser.Email = "test@test.com"
 			return newUser, nil
@@ -469,7 +469,7 @@ func TestSignUp(t *testing.T) {
 		usersCountFunc = func() (int64, restErrors.IRestErr) {
 			return 1, nil
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			return nil, restErrors.NewBadRequestError("user service errors")
 		}
 
@@ -488,7 +488,7 @@ func TestSignUp(t *testing.T) {
 		settingIsRegistrationEnabledFunc = func() bool {
 			return true
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			newUser := new(user.User)
 			newUser.Email = "test@test.com"
 			return newUser, nil
@@ -516,7 +516,7 @@ func TestSignUp(t *testing.T) {
 		settingIsRegistrationEnabledFunc = func() bool {
 			return true
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			newUser := new(user.User)
 			newUser.Email = "test@test.com"
 			return newUser, nil
@@ -547,7 +547,7 @@ func TestSignUp(t *testing.T) {
 		settingIsRegistrationEnabledFunc = func() bool {
 			return true
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			newUser := new(user.User)
 			newUser.Email = "test@test.com"
 			return newUser, nil
@@ -581,7 +581,7 @@ func TestSignUp(t *testing.T) {
 		settingIsRegistrationEnabledFunc = func() bool {
 			return true
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			newUser := new(user.User)
 			newUser.Email = "test@test.com"
 			return newUser, nil
@@ -618,7 +618,7 @@ func TestSignUp(t *testing.T) {
 		settingIsRegistrationEnabledFunc = func() bool {
 			return true
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			newUser := new(user.User)
 			newUser.Email = "test@test.com"
 			return newUser, nil
@@ -659,7 +659,7 @@ func TestSignUp(t *testing.T) {
 		settingIsRegistrationEnabledFunc = func() bool {
 			return true
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			return new(user.User), nil
 		}
 		usersCountFunc = func() (int64, restErrors.IRestErr) {
@@ -685,7 +685,7 @@ func TestSignUp(t *testing.T) {
 		settingIsRegistrationEnabledFunc = func() bool {
 			return true
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			newUser := new(user.User)
 			newUser.Email = "test@test.com"
 			return newUser, nil
@@ -717,7 +717,7 @@ func TestSignUp(t *testing.T) {
 		settingIsRegistrationEnabledFunc = func() bool {
 			return true
 		}
-		SignUpFunc = func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
+		SignUpFunc = func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
 			newUser := new(user.User)
 			newUser.Email = "test@test.com"
 			return newUser, nil

--- a/api/handler/workspace/handler_test.go
+++ b/api/handler/workspace/handler_test.go
@@ -29,7 +29,7 @@ User service Mocks
 */
 var (
 	UserWithTransactionFunc     func(txHandle *gorm.DB) user.IService
-	SignUpFunc                  func(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr)
+	SignUpFunc                  func(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr)
 	SignInFunc                  func(dto *user.SignInRequestDto) (*user.UserSessionResponseDto, restErrors.IRestErr)
 	VerifyTOTPFunc              func(model *user.User, totp string) (*user.UserSessionResponseDto, restErrors.IRestErr)
 	GetByEmailFunc              func(email string) (*user.User, restErrors.IRestErr)
@@ -56,8 +56,8 @@ func (uService userServiceMock) WithTransaction(txHandle *gorm.DB) user.IService
 	return uService
 }
 
-func (userServiceMock) SignUp(dto *user.SignUpRequestDto) (*user.User, restErrors.IRestErr) {
-	return SignUpFunc(dto)
+func (userServiceMock) SignUp(email string, password string, isCustomer bool) (*user.User, restErrors.IRestErr) {
+	return SignUpFunc(email, password, isCustomer)
 }
 
 func (userServiceMock) SignIn(dto *user.SignInRequestDto) (*user.UserSessionResponseDto, restErrors.IRestErr) {

--- a/core/user/dto.go
+++ b/core/user/dto.go
@@ -60,6 +60,7 @@ type UserResponseDto struct {
 	PublicUserResponseDto
 	TwoFactorEnabled bool `json:"two_factor_enabled"`
 	PlatformAdmin    bool `json:"platform_admin"`
+	IsCustomer       bool `json:"is_customer"`
 }
 
 type PublicUserResponseDto struct {

--- a/core/user/service_test.go
+++ b/core/user/service_test.go
@@ -121,8 +121,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestService_SignUp(t *testing.T) {
-	dto := new(SignUpRequestDto)
-	dto.Password = "123456"
+	email := "test@kotal.co"
+	password := "123456"
+	isCustomer := false
 
 	t.Run("Sign_Up_Should_Pass", func(t *testing.T) {
 		HashFunc = func(password string, cost int) ([]byte, error) {
@@ -133,10 +134,10 @@ func TestService_SignUp(t *testing.T) {
 			return nil
 		}
 
-		user, err := userService.SignUp(dto)
+		user, err := userService.SignUp(email, password, isCustomer)
 
 		assert.Nil(t, err)
-		assert.EqualValues(t, dto.Email, user.Email)
+		assert.EqualValues(t, email, user.Email)
 	})
 
 	t.Run("Sign_Up_Should_Throw_If_Repo_Throws", func(t *testing.T) {
@@ -148,7 +149,7 @@ func TestService_SignUp(t *testing.T) {
 			return restErrors.NewInternalServerError("something went wrong")
 		}
 
-		user, err := userService.SignUp(dto)
+		user, err := userService.SignUp(email, password, isCustomer)
 		assert.EqualValues(t, "something went wrong", err.Error())
 		assert.Nil(t, user)
 	})
@@ -158,7 +159,7 @@ func TestService_SignUp(t *testing.T) {
 			return nil, errors.New("")
 		}
 
-		user, err := userService.SignUp(dto)
+		user, err := userService.SignUp(email, password, isCustomer)
 		assert.Nil(t, user)
 		assert.EqualValues(t, "something went wrong.", err.Error())
 	})

--- a/core/user/user.go
+++ b/core/user/user.go
@@ -8,4 +8,5 @@ type User struct {
 	TwoFactorCipher  string
 	TwoFactorEnabled bool
 	PlatformAdmin    bool `gorm:"default:false"`
+	IsCustomer       bool `gorm:"default:false"`
 }


### PR DESCRIPTION
## Issue Description
### **Background** 
currently there is no difference between cloud-api users and managed-api users.
 
 ### **Requirements**
FrontEnd side should distinguish if their  users are  coming from the managed-api system or cloud-api system

 ### Proposed Changes
-  create a new field IsCustomer in users model 
- this field can't be updated using an API call  so we didn't add it in the [SignUpRequestDto](https://github.com/kotalco/cloud-api/blob/master/core/user/dto.go#L8C6-L8C22)
but we should add it as an argument in users.service file which gonna be accessed from the managed-api handlers or cloud-api handlers only