### PR TITLE
feat:add isCustomr Feild to userReponseDto it's always=false in cloud…

### DIFF
--- a/core/user/dto.go
+++ b/core/user/dto.go
@@ -60,6 +60,7 @@ type UserResponseDto struct {
 	PublicUserResponseDto
 	TwoFactorEnabled bool `json:"two_factor_enabled"`
 	PlatformAdmin    bool `json:"platform_admin"`
+	IsCustomer       bool `json:"is_customer"`
 }
 
 type PublicUserResponseDto struct {


### PR DESCRIPTION
## Description
currently the frontend can't distinguish cloud-api users from managed-api users
## Requirements
using the whoami endpoint frontend should be able to distinguish cloud-api users from managed-api users 
## Proposed changes

- Add IsCustomer field to UserResponseDto
- this field will always be false by default in the case of cloud-api
- in managed-api make sure it's true in the UserResponseDto