### PR TITLE
Add Label Support to ingressroute and endpoint Services

### DIFF
--- a/core/endpoint/dto.go
+++ b/core/endpoint/dto.go
@@ -17,6 +17,7 @@ type CreateEndpointDto struct {
 	ServiceName  string `json:"service_name" validate:"required"`
 	UseBasicAuth bool   `json:"use_basic_auth"`
 	UserId       string
+	Labels       map[string]string
 }
 
 type EndpointMetaDto struct {

--- a/pkg/k8s/ingressroute/dto.go
+++ b/pkg/k8s/ingressroute/dto.go
@@ -10,17 +10,14 @@ const (
 // IngressRouteDto defines the desired state of the traefikv1alpha1.IngressRoute
 // IngressRouteDto is the struct that matches the CRD implementation of a Traefik HTTP Router.
 type IngressRouteDto struct {
-	Name            string                // is the name of the ingress-route chosen by the user
-	Namespace       string                // is the namespace the user wishes to create the ingress-route in
-	ServiceName     string                // is the name of the service created by kotal operator
-	ServiceProtocol string                // is the protocol of which responsible for creating this service
-	ServiceNetwork  string                // is the network of which responsible for creating this service
-	ServiceKind     string                // is the kind of service created by kotal operator
-	ServiceID       string                // id of the service created by kotal operator
-	Ports           []IngressRoutePortDto // the corresponding ports of the targeted service
-	Middlewares     []IngressRouteMiddlewareRefDto
-	OwnersRef       []metav1.OwnerReference
-	UserId          string
+	Name        string                // is the name of the ingress-route chosen by the user
+	Namespace   string                // is the namespace the user wishes to create the ingress-route in
+	ServiceName string                // is the name of the service created by kotal operator
+	ServiceID   string                // id of the service created by kotal operator
+	Ports       []IngressRoutePortDto // the corresponding ports of the targeted service
+	Middlewares []IngressRouteMiddlewareRefDto
+	OwnersRef   []metav1.OwnerReference
+	Labels      map[string]string
 }
 
 type IngressRouteMiddlewareRefDto struct {

--- a/pkg/k8s/ingressroute/service.go
+++ b/pkg/k8s/ingressroute/service.go
@@ -70,7 +70,7 @@ func (i *ingressroute) Create(dto *IngressRouteDto) (*traefikv1alpha1.IngressRou
 			Name:            dto.Name,
 			Namespace:       dto.Namespace,
 			OwnerReferences: dto.OwnersRef,
-			Labels:          map[string]string{"app.kubernetes.io/created-by": "kotal-api", "kotal.io/protocol": dto.ServiceProtocol, "kotal.io/network": dto.ServiceNetwork, "kotal.io/kind": dto.ServiceKind, "kotal.io/user-id": dto.UserId},
+			Labels:          dto.Labels,
 		},
 		Spec: traefikv1alpha1.IngressRouteSpec{
 			EntryPoints: []string{"websecure"},


### PR DESCRIPTION
### Description
currently ingressroute service don't have labels as a part of it's createIngressRouteDto 

### Problem
The absence of dynamic label creations in the ingressroute service and the inability for the endpoint service to create and pass labels causes inflexibility for services like managed-api that require label creation like name.


### Proposed Changes

- ingressroute service should be label agnostic, it should accept and create any labels passed to it
- endpoint service should create necessary labels and pass them to the ingressroute service. This change will allow other services to communicate labels via the endpoint service like managed-ap
- include labels endpoint dto . This change will allow services like managed-api to use the endpoint service for label creation