### PR TITLE
fix docker image entrypoint path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ COPY --from=builder /api/server /home/kotal/api/server
 WORKDIR /home/kotal
 EXPOSE 8080
 ENV ETCD_UNSUPPORTED_ARCH=arm64
-ENTRYPOINT [ "./api/server" ]
+ENTRYPOINT [ "./api/server/cloud-api" ]


### PR DESCRIPTION
To fix/update docker image entrypoint path
from /api/server to /api/server/cloud-api